### PR TITLE
fix issue where | needs to be url encoded or you get invalid URI erro…

### DIFF
--- a/lib/qmetrics/caller.rb
+++ b/lib/qmetrics/caller.rb
@@ -19,8 +19,9 @@ module Qmetrics
       execute
     end
 
+    # url encoded '|' to '%7C'
     def to_s
-      "/jsonStatsApi.do?queues=#{@queues.join("|")}"
+      "/jsonStatsApi.do?queues=#{@queues.join('%7C')}"
     end
 
     def self.load_api_methods(file)


### PR DESCRIPTION
…rs URI::InvalidURIError: bad URI(is not URI?): http://127.0.0.1:8080/queuemetrics//QmStats/jsonStatsApi.do?queues=100|200&from=2015-12-20.21:15:27&to=2015-12-21.21:15:27&block=OkDO.RiassAllCalls

So I thought about using a method to do this, but for this simple case seemed just commenting and adding the encoded string was better than trying to track the best place to encode the whole URL. 

Also, I didn't see a rake task to run the spec suite, when I tried to run by hand I received errors. Hopefully this is cool without a test. If you want me to add a test happy to do so if you could add some documentation on how to get the test suite passing.
